### PR TITLE
Integrate weapon damage with IDamageable system

### DIFF
--- a/Assets/Scenes/WeaponsTest.unity
+++ b/Assets/Scenes/WeaponsTest.unity
@@ -343,7 +343,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7030228865390730449, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -352,6 +352,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7030228865390730449, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
       insertIndex: -1
       addedObject: {fileID: 733341456}
+    - targetCorrespondingSourceObject: {fileID: 6165108467720621144, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 706114735}
   m_SourcePrefab: {fileID: 100100000, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
 --- !u!1 &410087039
 GameObject:
@@ -592,6 +595,33 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 414649419}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &706114731 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6165108467720621144, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
+  m_PrefabInstance: {fileID: 387417977}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &706114735
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 706114731}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300002, guid: a2e2dc37c1fdbdd419db3632766d70aa, type: 3}
 --- !u!1 &733341449 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7030228865390730449, guid: c2b62d67c2ea4974db0e4797d9038909, type: 3}
@@ -1018,7 +1048,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9084033339816492650, guid: bf7bc79f31de6854b8e7283d14a53727, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Player/Weapons/Minigun/Bullet.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/Bullet.cs
@@ -6,21 +6,25 @@ public class Bullet : MonoBehaviour, IPoolable
     [SerializeField] private float speed = 200f;
     [SerializeField] private float lifeTime = 3f;
 
+    [Header("Damage")]
+    [SerializeField] private float damage = 10f;
+
     [Header("Impact Audio")]
     [SerializeField] private AudioClip impactClip;
     [SerializeField] private AudioClip enemyImpactClip;
     [SerializeField] private float impactVolume = 1f;
     [SerializeField] private float enemyImpactVolume = 1f;
 
-    [Header("Impact Pools")]
+    private Rigidbody rb;
+    private Vector3 direction;
+
+    private ObjectPool ownerPool;
+
     private ObjectPool impactVfxPool;
     private ObjectPool enemyImpactVfxPool;
     private ObjectPool impactAudioPool;
     private ObjectPool enemyImpactAudioPool;
 
-    private Rigidbody rb;
-    private Vector3 direction;
-    private ObjectPool ownerPool;
     private float lifeTimer;
     private bool isReturning;
 
@@ -101,35 +105,57 @@ public class Bullet : MonoBehaviour, IPoolable
             return;
 
         Vector3 hitPoint = collision.contacts[0].point;
-        bool isEnemy = collision.gameObject.CompareTag("Enemy");
 
-        if (isEnemy)
+        IDamageable damageable = FindDamageable(collision);
+
+        bool hitDamageable = damageable != null;
+
+        if (hitDamageable)
         {
+            damageable.TakeDamage(damage);
+
             SpawnVfx(enemyImpactVfxPool, hitPoint);
-            PlayImpactAudio(enemyImpactAudioPool, enemyImpactClip, enemyImpactVolume, hitPoint);
+
+            PlayImpactAudio(
+                enemyImpactAudioPool,
+                enemyImpactClip,
+                enemyImpactVolume,
+                hitPoint
+            );
         }
         else
         {
             SpawnVfx(impactVfxPool, hitPoint);
-            PlayImpactAudio(impactAudioPool, impactClip, impactVolume, hitPoint);
+
+            PlayImpactAudio(
+                impactAudioPool,
+                impactClip,
+                impactVolume,
+                hitPoint
+            );
         }
 
         ReturnToPool();
     }
 
-    void ReturnToPool()
+    IDamageable FindDamageable(Collision collision)
     {
-        if (isReturning)
-            return;
+        IDamageable damageable =
+            collision.collider.GetComponentInParent<IDamageable>();
 
-        if (ownerPool != null)
-        {
-            ownerPool.Return(gameObject);
-        }
-        else
-        {
-            gameObject.SetActive(false);
-        }
+        if (damageable != null)
+            return damageable;
+
+        damageable =
+            collision.collider.GetComponentInChildren<IDamageable>();
+
+        if (damageable != null)
+            return damageable;
+
+        damageable =
+            collision.gameObject.GetComponent<IDamageable>();
+
+        return damageable;
     }
 
     void SpawnVfx(ObjectPool pool, Vector3 position)
@@ -145,7 +171,8 @@ public class Bullet : MonoBehaviour, IPoolable
         vfx.transform.position = position;
         vfx.transform.rotation = Quaternion.identity;
 
-        PooledAutoReturn pooledAutoReturn = vfx.GetComponent<PooledAutoReturn>();
+        PooledAutoReturn pooledAutoReturn =
+            vfx.GetComponent<PooledAutoReturn>();
 
         if (pooledAutoReturn != null)
         {
@@ -153,7 +180,12 @@ public class Bullet : MonoBehaviour, IPoolable
         }
     }
 
-    void PlayImpactAudio(ObjectPool pool, AudioClip clip, float volume, Vector3 position)
+    void PlayImpactAudio(
+        ObjectPool pool,
+        AudioClip clip,
+        float volume,
+        Vector3 position
+    )
     {
         if (pool == null || clip == null)
             return;
@@ -165,11 +197,27 @@ public class Bullet : MonoBehaviour, IPoolable
 
         audioObj.transform.position = position;
 
-        PooledAudio pooledAudio = audioObj.GetComponent<PooledAudio>();
+        PooledAudio pooledAudio =
+            audioObj.GetComponent<PooledAudio>();
 
         if (pooledAudio != null)
         {
             pooledAudio.Initialize(pool, clip, volume);
+        }
+    }
+
+    void ReturnToPool()
+    {
+        if (isReturning)
+            return;
+
+        if (ownerPool != null)
+        {
+            ownerPool.Return(gameObject);
+        }
+        else
+        {
+            gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/Player/Weapons/Missile/Missile.cs
+++ b/Assets/Scripts/Player/Weapons/Missile/Missile.cs
@@ -8,11 +8,9 @@ public class Missile : MonoBehaviour, IPoolable
     [Header("Lifetime")]
     [SerializeField] private float lifeTime = 3f;
 
-    [Header("Explosion")]
-    private ObjectPool explosionVfxPool;
-
     [Header("Damage")]
     [SerializeField] private float explosionRadius = 10f;
+    [SerializeField] private float damage = 50f;
 
     [Header("Engine VFX")]
     [SerializeField] private ParticleSystem launchBurstVfx;
@@ -23,11 +21,13 @@ public class Missile : MonoBehaviour, IPoolable
     [SerializeField] private AudioClip launchClip;
 
     private Rigidbody rb;
+
     private ObjectPool ownerPool;
+    private ObjectPool explosionVfxPool;
+    private ObjectPool launchAudioPool;
+
     private float lifeTimer;
     private bool isReturning;
-    private ObjectPool launchAudioPool;
-    
 
     void Awake()
     {
@@ -38,11 +38,10 @@ public class Missile : MonoBehaviour, IPoolable
         ObjectPool pool,
         ObjectPool explosionPool,
         ObjectPool missileLaunchAudioPool
-        )
+    )
     {
         ownerPool = pool;
         explosionVfxPool = explosionPool;
-
         launchAudioPool = missileLaunchAudioPool;
 
         lifeTimer = lifeTime;
@@ -141,38 +140,114 @@ public class Missile : MonoBehaviour, IPoolable
 
     void Explode()
     {
+        StopFlightAudio();
+
+        SpawnExplosionVfx();
+
+        ApplyAreaDamage();
+
+        ReturnToPool();
+    }
+
+    void ApplyAreaDamage()
+    {
+        Collider[] hitColliders = Physics.OverlapSphere(
+            transform.position,
+            explosionRadius
+        );
+
+        foreach (Collider hit in hitColliders)
+        {
+            IDamageable damageable = FindDamageable(hit);
+
+            if (damageable != null)
+            {
+                damageable.TakeDamage(damage);
+            }
+        }
+    }
+
+    IDamageable FindDamageable(Collider hit)
+    {
+        IDamageable damageable =
+            hit.GetComponentInParent<IDamageable>();
+
+        if (damageable != null)
+            return damageable;
+
+        damageable =
+            hit.GetComponentInChildren<IDamageable>();
+
+        if (damageable != null)
+            return damageable;
+
+        damageable =
+            hit.GetComponent<IDamageable>();
+
+        return damageable;
+    }
+
+    void SpawnExplosionVfx()
+    {
+        if (explosionVfxPool == null)
+            return;
+
+        GameObject explosion = explosionVfxPool.Get();
+
+        if (explosion == null)
+            return;
+
+        explosion.transform.position = transform.position;
+        explosion.transform.rotation = Quaternion.identity;
+
+        PooledAutoReturn pooledAutoReturn =
+            explosion.GetComponent<PooledAutoReturn>();
+
+        if (pooledAutoReturn != null)
+        {
+            pooledAutoReturn.Initialize(explosionVfxPool);
+        }
+
+        AudioSource audioSource =
+            explosion.GetComponent<AudioSource>();
+
+        if (audioSource != null)
+        {
+            audioSource.Play();
+        }
+    }
+
+    void PlayLaunchAudio()
+    {
+        if (launchAudioPool == null || launchClip == null)
+            return;
+
+        GameObject audioObj = launchAudioPool.Get();
+
+        if (audioObj == null)
+            return;
+
+        audioObj.transform.position = transform.position;
+
+        PooledAudio pooledAudio =
+            audioObj.GetComponent<PooledAudio>();
+
+        if (pooledAudio != null)
+        {
+            pooledAudio.Initialize(
+                launchAudioPool,
+                launchClip,
+                1f
+            );
+        }
+    }
+
+    void StopFlightAudio()
+    {
         if (flightAudio != null)
         {
             flightAudio.Stop();
         }
-
-       if (explosionVfxPool != null)
-        {
-            GameObject explosion = explosionVfxPool.Get();
-
-            if (explosion != null)
-            {
-                explosion.transform.position = transform.position;
-                explosion.transform.rotation = Quaternion.identity;
-
-                PooledAutoReturn pooledAutoReturn =
-                    explosion.GetComponent<PooledAutoReturn>();
-
-                if (pooledAutoReturn != null)
-                {
-                    pooledAutoReturn.Initialize(explosionVfxPool);
-                }
-
-                AudioSource audioSource = explosion.GetComponent<AudioSource>();
-
-                if (audioSource != null)
-                {
-                    audioSource.Play();
-                }
-            }
-        }
-
-        ReturnToPool();
     }
 
     void ReturnToPool()
@@ -190,29 +265,13 @@ public class Missile : MonoBehaviour, IPoolable
         }
     }
 
-    void PlayLaunchAudio()
-    {
-        if (launchAudioPool == null || launchClip == null)
-            return;
-
-        GameObject audioObj = launchAudioPool.Get();
-
-        if (audioObj == null)
-            return;
-
-        audioObj.transform.position = transform.position;
-
-        PooledAudio pooledAudio = audioObj.GetComponent<PooledAudio>();
-
-        if (pooledAudio != null)
-        {
-            pooledAudio.Initialize(launchAudioPool, launchClip, 1f);
-        }
-    }
-
     void OnDrawGizmos()
     {
         Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(transform.position, explosionRadius);
+
+        Gizmos.DrawWireSphere(
+            transform.position,
+            explosionRadius
+        );
     }
 }


### PR DESCRIPTION
Integrated player weapon damage with the shared IDamageable interface.

Changes:
- Updated minigun bullet collision to damage IDamageable targets
- Updated missile explosion radius damage to use IDamageable
- Supports TurretHealth and GuidedHealth without modifying those scripts
- Uses GetComponentInParent/GetComponentInChildren for safer collider hierarchy handling

Tested:
- Minigun damages AA turret
- Missile explosion damages targets within radius
- Existing VFX/audio feedback remains functional