### PR TITLE
Feat: Implement fuel can drop upon turret and guided launcher destruc…

### DIFF
--- a/Assets/Prefebs/AA/AA_Turret.prefab
+++ b/Assets/Prefebs/AA/AA_Turret.prefab
@@ -513,6 +513,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::TurretHealth
   maxHealth: 50
   explosionPrefab: {fileID: 100008, guid: 1ae4db7b36e51124b89d2b32303a7a0b, type: 3}
+  fuelCanPrefab: {fileID: 8480765971192770263, guid: 4b3d575113620f443990fb17a6c830ab, type: 3}
 --- !u!82 &-7667499693039314754
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Prefebs/Guided/Missile Launcher.prefab
+++ b/Assets/Prefebs/Guided/Missile Launcher.prefab
@@ -353,6 +353,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GuidedHealth
   maxHealth: 100
   explosionPrefab: {fileID: 100010, guid: d609d5ebc845aca409f72e9c6a56dc60, type: 3}
+  fuelCanPrefab: {fileID: 8480765971192770263, guid: 4b3d575113620f443990fb17a6c830ab, type: 3}
 --- !u!65 &4013742159863071621
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Hazards and Health/AA/TurretHealth.cs
+++ b/Assets/Scripts/Hazards and Health/AA/TurretHealth.cs
@@ -8,6 +8,9 @@ public class TurretHealth : MonoBehaviour, IDamageable
     [Header("Effects")]
     [SerializeField] private GameObject explosionPrefab;
 
+    [Header("Loot Settings")]
+    [SerializeField] private GameObject fuelCanPrefab;
+
     private void Start()
     {
         currentHealth = maxHealth;
@@ -29,6 +32,11 @@ public class TurretHealth : MonoBehaviour, IDamageable
         if (explosionPrefab != null)
         {
             Instantiate(explosionPrefab, transform.position, transform.rotation);
+        }
+
+        if (fuelCanPrefab != null)
+        {
+            Instantiate(fuelCanPrefab, transform.position, Quaternion.identity); 
         }
 
         Destroy(gameObject);

--- a/Assets/Scripts/Hazards and Health/Guided/GuidedHealth.cs
+++ b/Assets/Scripts/Hazards and Health/Guided/GuidedHealth.cs
@@ -2,38 +2,24 @@ using UnityEngine;
 
 public class GuidedHealth : MonoBehaviour, IDamageable
 {
-    [Header("Health Settings")]
-    [SerializeField] private float maxHealth = 100f;
+    [SerializeField] private float maxHealth = 50f;
+    private float currentHealth;
+
+    [Header("Effects")]
     [SerializeField] private GameObject explosionPrefab;
 
-    private float currentHealth;
-    private bool isDead = false;
-
-    public float CurrentHealth => currentHealth;
-    public float MaxHealth => maxHealth;
-    public bool IsAlive => !isDead;
+    [Header("Loot Settings")]
+    [SerializeField] private GameObject fuelCanPrefab;
 
     private void Start()
     {
         currentHealth = maxHealth;
     }
 
-    public void TakeDamage(float damage)
+    public void TakeDamage(float damageAmount)
     {
-        ExecuteDamage(damage);
-    }
-
-    public void TakeDamage(float damage, GameObject attacker)
-    {
-        ExecuteDamage(damage);
-    }
-
-    private void ExecuteDamage(float damage)
-    {
-        if (isDead) return;
-
-        currentHealth -= damage;
-        currentHealth = Mathf.Clamp(currentHealth, 0f, maxHealth);
+        currentHealth -= damageAmount;
+        Debug.Log("Guided Launcher Health: " + currentHealth);
 
         if (currentHealth <= 0f)
         {
@@ -43,11 +29,14 @@ public class GuidedHealth : MonoBehaviour, IDamageable
 
     private void Die()
     {
-        isDead = true;
-
         if (explosionPrefab != null)
         {
             Instantiate(explosionPrefab, transform.position, transform.rotation);
+        }
+
+        if (fuelCanPrefab != null)
+        {
+            Instantiate(fuelCanPrefab, transform.position, Quaternion.identity);
         }
 
         Destroy(gameObject);


### PR DESCRIPTION
* **Fuel Can Drop Mechanism:** Integrated `fuelCanPrefab` into both `TurretHealth` and `GuidedHealth` scripts. 
* **Loot Spawn:** When any anti-air turret or guided launcher's health drops to 0, they will now dynamically spawn a ready-to-collect fuel can at their exact death location.
