### PR TITLE
Refactor minigun state management using State Pattern

### DIFF
--- a/Assets/Scripts/Architecture/Interfaces/IMinigunState.cs
+++ b/Assets/Scripts/Architecture/Interfaces/IMinigunState.cs
@@ -1,0 +1,6 @@
+public interface IMinigunState
+{
+    void Enter(Minigun minigun);
+    void Update(Minigun minigun);
+    void Exit(Minigun minigun);
+}

--- a/Assets/Scripts/Architecture/Interfaces/IMinigunState.cs.meta
+++ b/Assets/Scripts/Architecture/Interfaces/IMinigunState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a46a298341f84964484d72d2af728895

--- a/Assets/Scripts/Player/Weapons/Minigun/Minigun.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/Minigun.cs
@@ -3,14 +3,6 @@ using UnityEngine.InputSystem;
 
 public class Minigun : MonoBehaviour
 {
-    public enum MinigunState
-    {
-        Idle,
-        Firing,
-        Overheated,
-        Cooling
-    }
-
     [Header("References")]
     [SerializeField] private Transform[] firePoints;
     [SerializeField] private ObjectPool bulletPool;
@@ -34,132 +26,84 @@ public class Minigun : MonoBehaviour
     [SerializeField] private AudioSource firingAudio;
     [SerializeField] private AudioSource overheatAudio;
 
-    private MinigunState currentState = MinigunState.Idle;
+    private IMinigunState currentState;
 
     private float stateTimer;
     private float fireStartTime;
     private float nextFireTime;
 
+    void Start()
+    {
+        ChangeState(new MinigunIdleState());
+    }
+
     void Update()
     {
-        HandleInput();
-        HandleState();
+        currentState?.Update(this);
     }
 
-    void HandleInput()
+    public void ChangeState(IMinigunState newState)
     {
-        if (Mouse.current == null)
-            return;
-
-        bool isPressed = Mouse.current.leftButton.isPressed;
-
-        if (isPressed)
-        {
-            if (currentState == MinigunState.Idle)
-            {
-                EnterState(MinigunState.Firing);
-            }
-        }
-        else
-        {
-            if (currentState == MinigunState.Firing)
-            {
-                EnterState(MinigunState.Idle);
-            }
-        }
+        currentState?.Exit(this);
+        currentState = newState;
+        currentState.Enter(this);
     }
 
-    void HandleState()
+    public bool IsFirePressed()
+    {
+        return Mouse.current != null && Mouse.current.leftButton.isPressed;
+    }
+
+    public void TickStateTimer()
     {
         stateTimer -= Time.deltaTime;
-
-        switch (currentState)
-        {
-            case MinigunState.Firing:
-
-                HandleFire();
-
-                if (stateTimer <= 0f)
-                {
-                    EnterState(MinigunState.Overheated);
-                }
-
-                break;
-
-            case MinigunState.Overheated:
-
-                if (stateTimer <= 0f)
-                {
-                    EnterState(MinigunState.Cooling);
-                }
-
-                break;
-
-            case MinigunState.Cooling:
-
-                if (stateTimer <= 0f)
-                {
-                    WeaponEvents.RaiseMinigunCooldownFinished();
-                    EnterState(MinigunState.Idle);
-                }
-
-                break;
-        }
     }
 
-    void EnterState(MinigunState newState)
+    public bool IsStateTimerFinished()
     {
-        currentState = newState;
+        return stateTimer <= 0f;
+    }
 
+    public void ResetStateTimer()
+    {
+        stateTimer = 0f;
+    }
+
+    public void StartFiringState()
+    {
         StopAllAudio();
 
-        switch (newState)
-        {
-            case MinigunState.Idle:
+        firingAudio?.Play();
 
-                stateTimer = 0f;
-
-                break;
-
-            case MinigunState.Firing:
-
-                firingAudio?.Play();
-
-                stateTimer = firingDuration;
-
-                fireStartTime = Time.time + spinUpDelay;
-                nextFireTime = fireStartTime;
-
-                break;
-
-            case MinigunState.Overheated:
-
-                overheatAudio?.Play();
-
-                stateTimer =
-                    overheatAudio != null
-                    ? overheatAudio.clip.length
-                    : 1.5f;
-
-                WeaponEvents.RaiseMinigunOverheated();
-
-                break;
-
-            case MinigunState.Cooling:
-
-                stateTimer = cooldownTime;
-
-                break;
-        }
+        stateTimer = firingDuration;
+        fireStartTime = Time.time + spinUpDelay;
+        nextFireTime = fireStartTime;
     }
 
-    void HandleFire()
+    public void StartOverheatedState()
     {
-        if (Mouse.current == null ||
-            !Mouse.current.leftButton.isPressed)
-        {
+        StopAllAudio();
+
+        overheatAudio?.Play();
+
+        stateTimer =
+            overheatAudio != null
+            ? overheatAudio.clip.length
+            : 1.5f;
+
+        WeaponEvents.RaiseMinigunOverheated();
+    }
+
+    public void StartCoolingState()
+    {
+        StopAllAudio();
+        stateTimer = cooldownTime;
+    }
+
+    public void HandleFire()
+    {
+        if (!IsFirePressed())
             return;
-        }
 
         if (Time.time < fireStartTime)
             return;
@@ -167,7 +111,6 @@ public class Minigun : MonoBehaviour
         if (Time.time >= nextFireTime)
         {
             Shoot();
-
             nextFireTime = Time.time + fireRate;
         }
     }
@@ -205,7 +148,7 @@ public class Minigun : MonoBehaviour
         }
     }
 
-    void StopAllAudio()
+    public void StopAllAudio()
     {
         firingAudio?.Stop();
         overheatAudio?.Stop();

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates.meta
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11ee2a2f4f9e74442aecc62ce0e4e57a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunCoolingState.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunCoolingState.cs
@@ -1,0 +1,22 @@
+public class MinigunCoolingState : IMinigunState
+{
+    public void Enter(Minigun minigun)
+    {
+        minigun.StartCoolingState();
+    }
+
+    public void Update(Minigun minigun)
+    {
+        minigun.TickStateTimer();
+
+        if (minigun.IsStateTimerFinished())
+        {
+            WeaponEvents.RaiseMinigunCooldownFinished();
+            minigun.ChangeState(new MinigunIdleState());
+        }
+    }
+
+    public void Exit(Minigun minigun)
+    {
+    }
+}

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunCoolingState.cs.meta
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunCoolingState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed29f186d2d2d3d48836435c190a7a9c

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunFiringState.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunFiringState.cs
@@ -1,0 +1,29 @@
+public class MinigunFiringState : IMinigunState
+{
+    public void Enter(Minigun minigun)
+    {
+        minigun.StartFiringState();
+    }
+
+    public void Update(Minigun minigun)
+    {
+        if (!minigun.IsFirePressed())
+        {
+            minigun.ChangeState(new MinigunIdleState());
+            return;
+        }
+
+        minigun.TickStateTimer();
+
+        minigun.HandleFire();
+
+        if (minigun.IsStateTimerFinished())
+        {
+            minigun.ChangeState(new MinigunOverheatedState());
+        }
+    }
+
+    public void Exit(Minigun minigun)
+    {
+    }
+}

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunFiringState.cs.meta
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunFiringState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5fe55de9ecb26b4428dec75e2f0b36af

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunIdleState.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunIdleState.cs
@@ -1,0 +1,20 @@
+public class MinigunIdleState : IMinigunState
+{
+    public void Enter(Minigun minigun)
+    {
+        minigun.StopAllAudio();
+        minigun.ResetStateTimer();
+    }
+
+    public void Update(Minigun minigun)
+    {
+        if (minigun.IsFirePressed())
+        {
+            minigun.ChangeState(new MinigunFiringState());
+        }
+    }
+
+    public void Exit(Minigun minigun)
+    {
+    }
+}

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunIdleState.cs.meta
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunIdleState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 849a08f7375c358499317e0bb0a73489

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunOverheatedState.cs
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunOverheatedState.cs
@@ -1,0 +1,21 @@
+public class MinigunOverheatedState : IMinigunState
+{
+    public void Enter(Minigun minigun)
+    {
+        minigun.StartOverheatedState();
+    }
+
+    public void Update(Minigun minigun)
+    {
+        minigun.TickStateTimer();
+
+        if (minigun.IsStateTimerFinished())
+        {
+            minigun.ChangeState(new MinigunCoolingState());
+        }
+    }
+
+    public void Exit(Minigun minigun)
+    {
+    }
+}

--- a/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunOverheatedState.cs.meta
+++ b/Assets/Scripts/Player/Weapons/Minigun/MinigunStates/MinigunOverheatedState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dbccf841f496d6545a2e73f5909d807f


### PR DESCRIPTION
Replaced enum-based switch state management in Minigun with the State Pattern.

Changes:
- Added IMinigunState interface
- Added Idle, Firing, Overheated and Cooling state classes
- Removed switch-based state handling
- Moved state-specific behavior into dedicated state objects

Benefits:
- Better scalability for future states
- Improved maintainability
- Cleaner separation of responsibilities
- Follows State Pattern design principles